### PR TITLE
feat: CLI argument parsing and main conversion pipeline

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,1 +1,420 @@
-// TODO: CLI argument parsing
+use clap::Parser;
+use std::fmt;
+use std::path::PathBuf;
+
+/// Supported data formats.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Format {
+    Json,
+    Yaml,
+    Toml,
+    Csv,
+}
+
+impl Format {
+    /// All known formats and their display names.
+    pub fn all() -> &'static [(Format, &'static str, &'static [&'static str])] {
+        &[
+            (Format::Json, "JSON", &["json"]),
+            (Format::Yaml, "YAML", &["yaml", "yml"]),
+            (Format::Toml, "TOML", &["toml"]),
+            (Format::Csv, "CSV", &["csv"]),
+        ]
+    }
+
+    /// Detect format from a file extension.
+    pub fn from_extension(ext: &str) -> Option<Format> {
+        match ext.to_lowercase().as_str() {
+            "json" => Some(Format::Json),
+            "yaml" | "yml" => Some(Format::Yaml),
+            "toml" => Some(Format::Toml),
+            "csv" => Some(Format::Csv),
+            _ => None,
+        }
+    }
+
+    /// Detect format from a file path (by extension).
+    pub fn from_path(path: &std::path::Path) -> Option<Format> {
+        path.extension()
+            .and_then(|e| e.to_str())
+            .and_then(Format::from_extension)
+    }
+
+    /// Parse a format name string.
+    pub fn from_name(name: &str) -> Option<Format> {
+        match name.to_lowercase().as_str() {
+            "json" => Some(Format::Json),
+            "yaml" | "yml" => Some(Format::Yaml),
+            "toml" => Some(Format::Toml),
+            "csv" => Some(Format::Csv),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for Format {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Format::Json => write!(f, "json"),
+            Format::Yaml => write!(f, "yaml"),
+            Format::Toml => write!(f, "toml"),
+            Format::Csv => write!(f, "csv"),
+        }
+    }
+}
+
+/// morph — a universal data format converter
+#[derive(Parser, Debug)]
+#[command(name = "morph", version, about = "Convert between data formats")]
+pub struct Cli {
+    /// Input file (reads from stdin if not specified)
+    #[arg(short = 'i', long = "input")]
+    pub input: Option<PathBuf>,
+
+    /// Output file (writes to stdout if not specified)
+    #[arg(short = 'o', long = "output")]
+    pub output: Option<PathBuf>,
+
+    /// Input format (auto-detected from file extension if not specified)
+    #[arg(short = 'f', long = "from")]
+    pub from: Option<String>,
+
+    /// Output format (auto-detected from file extension if not specified)
+    #[arg(short = 't', long = "to")]
+    pub to: Option<String>,
+
+    /// Pretty-print output (default for TTY)
+    #[arg(long = "pretty", conflicts_with = "compact")]
+    pub pretty: bool,
+
+    /// Compact output (default for pipes)
+    #[arg(long = "compact", conflicts_with = "pretty")]
+    pub compact: bool,
+
+    /// Indentation width (spaces)
+    #[arg(long = "indent")]
+    pub indent: Option<usize>,
+
+    /// List supported formats
+    #[arg(long = "formats")]
+    pub formats: bool,
+}
+
+impl Cli {
+    /// Parse arguments from the command line.
+    pub fn parse_args() -> Self {
+        Cli::parse()
+    }
+
+    /// Resolve the input format from the `--from` flag or the input file extension.
+    pub fn resolve_input_format(&self) -> crate::error::Result<Format> {
+        if let Some(ref name) = self.from {
+            return Format::from_name(name).ok_or_else(|| {
+                crate::error::MorphError::cli(format!("unknown input format: '{name}'"))
+            });
+        }
+        if let Some(ref path) = self.input {
+            return Format::from_path(path).ok_or_else(|| {
+                crate::error::MorphError::cli(format!(
+                    "cannot detect format from '{}', use -f/--from to specify",
+                    path.display()
+                ))
+            });
+        }
+        Err(crate::error::MorphError::cli(
+            "reading from stdin requires -f/--from to specify input format",
+        ))
+    }
+
+    /// Resolve the output format from the `--to` flag or the output file extension.
+    pub fn resolve_output_format(&self) -> crate::error::Result<Format> {
+        if let Some(ref name) = self.to {
+            return Format::from_name(name).ok_or_else(|| {
+                crate::error::MorphError::cli(format!("unknown output format: '{name}'"))
+            });
+        }
+        if let Some(ref path) = self.output {
+            return Format::from_path(path).ok_or_else(|| {
+                crate::error::MorphError::cli(format!(
+                    "cannot detect format from '{}', use -t/--to to specify",
+                    path.display()
+                ))
+            });
+        }
+        Err(crate::error::MorphError::cli(
+            "writing to stdout requires -t/--to to specify output format",
+        ))
+    }
+}
+
+/// Read input data based on the CLI args.
+pub fn read_input(cli: &Cli) -> crate::error::Result<String> {
+    match &cli.input {
+        Some(path) => std::fs::read_to_string(path).map_err(|e| {
+            crate::error::MorphError::Io(std::io::Error::new(
+                e.kind(),
+                format!("{}: {e}", path.display()),
+            ))
+        }),
+        None => {
+            use std::io::Read;
+            let mut buf = String::new();
+            std::io::stdin().read_to_string(&mut buf)?;
+            Ok(buf)
+        }
+    }
+}
+
+/// Parse input string according to format.
+pub fn parse_input(input: &str, format: Format) -> crate::error::Result<crate::value::Value> {
+    match format {
+        Format::Json => crate::formats::json::from_str(input),
+        Format::Yaml => crate::formats::yaml::from_str(input),
+        Format::Toml => crate::formats::toml::from_str(input),
+        Format::Csv => crate::formats::csv::from_str(input),
+    }
+}
+
+/// Serialize a value to string according to format and pretty-print preference.
+pub fn serialize_output(
+    value: &crate::value::Value,
+    format: Format,
+    pretty: bool,
+) -> crate::error::Result<String> {
+    match format {
+        Format::Json => {
+            if pretty {
+                crate::formats::json::to_string_pretty(value)
+            } else {
+                crate::formats::json::to_string(value)
+            }
+        }
+        Format::Yaml => crate::formats::yaml::to_string(value),
+        Format::Toml => crate::formats::toml::to_string(value),
+        Format::Csv => crate::formats::csv::to_string(value),
+    }
+}
+
+/// Write output string to file or stdout.
+pub fn write_output(cli: &Cli, output: &str) -> crate::error::Result<()> {
+    match &cli.output {
+        Some(path) => std::fs::write(path, output).map_err(|e| {
+            crate::error::MorphError::Io(std::io::Error::new(
+                e.kind(),
+                format!("{}: {e}", path.display()),
+            ))
+        }),
+        None => {
+            print!("{output}");
+            Ok(())
+        }
+    }
+}
+
+/// Run the full pipeline based on CLI args.
+pub fn run(cli: &Cli) -> crate::error::Result<()> {
+    if cli.formats {
+        println!("Supported formats:");
+        for (_, name, extensions) in Format::all() {
+            println!("  {name} (extensions: {})", extensions.join(", "));
+        }
+        return Ok(());
+    }
+
+    let in_fmt = cli.resolve_input_format()?;
+    let out_fmt = cli.resolve_output_format()?;
+
+    let input_data = read_input(cli)?;
+    let value = parse_input(&input_data, in_fmt)?;
+
+    // Determine pretty-printing: explicit flags > default based on TTY
+    let pretty = if cli.pretty {
+        true
+    } else if cli.compact {
+        false
+    } else {
+        // Default: pretty for file output or TTY stdout, compact for piped
+        cli.output.is_some() || atty_stdout()
+    };
+
+    let output_data = serialize_output(&value, out_fmt, pretty)?;
+    write_output(cli, &output_data)?;
+
+    Ok(())
+}
+
+/// Check if stdout is a TTY (best-effort).
+fn atty_stdout() -> bool {
+    use std::io::IsTerminal;
+    std::io::stdout().is_terminal()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- Format detection ---------------------------------------------------
+
+    #[test]
+    fn format_from_extension_json() {
+        assert_eq!(Format::from_extension("json"), Some(Format::Json));
+    }
+
+    #[test]
+    fn format_from_extension_yaml() {
+        assert_eq!(Format::from_extension("yaml"), Some(Format::Yaml));
+        assert_eq!(Format::from_extension("yml"), Some(Format::Yaml));
+    }
+
+    #[test]
+    fn format_from_extension_toml() {
+        assert_eq!(Format::from_extension("toml"), Some(Format::Toml));
+    }
+
+    #[test]
+    fn format_from_extension_csv() {
+        assert_eq!(Format::from_extension("csv"), Some(Format::Csv));
+    }
+
+    #[test]
+    fn format_from_extension_unknown() {
+        assert_eq!(Format::from_extension("xyz"), None);
+    }
+
+    #[test]
+    fn format_from_path_json() {
+        let p = PathBuf::from("data.json");
+        assert_eq!(Format::from_path(&p), Some(Format::Json));
+    }
+
+    #[test]
+    fn format_from_path_yaml() {
+        let p = PathBuf::from("config.yaml");
+        assert_eq!(Format::from_path(&p), Some(Format::Yaml));
+
+        let p2 = PathBuf::from("config.yml");
+        assert_eq!(Format::from_path(&p2), Some(Format::Yaml));
+    }
+
+    #[test]
+    fn format_from_name() {
+        assert_eq!(Format::from_name("json"), Some(Format::Json));
+        assert_eq!(Format::from_name("JSON"), Some(Format::Json));
+        assert_eq!(Format::from_name("yaml"), Some(Format::Yaml));
+        assert_eq!(Format::from_name("toml"), Some(Format::Toml));
+        assert_eq!(Format::from_name("csv"), Some(Format::Csv));
+        assert_eq!(Format::from_name("xml"), None);
+    }
+
+    // -- Arg parsing --------------------------------------------------------
+
+    #[test]
+    fn arg_parsing_basic() {
+        let cli = Cli::try_parse_from(["morph", "-i", "input.json", "-o", "output.yaml"]).unwrap();
+        assert_eq!(cli.input, Some(PathBuf::from("input.json")));
+        assert_eq!(cli.output, Some(PathBuf::from("output.yaml")));
+    }
+
+    #[test]
+    fn arg_parsing_format_flags() {
+        let cli = Cli::try_parse_from(["morph", "-f", "json", "-t", "toml"]).unwrap();
+        assert_eq!(cli.from, Some("json".to_string()));
+        assert_eq!(cli.to, Some("toml".to_string()));
+    }
+
+    #[test]
+    fn arg_parsing_pretty() {
+        let cli = Cli::try_parse_from(["morph", "--pretty", "-f", "json", "-t", "json"]).unwrap();
+        assert!(cli.pretty);
+        assert!(!cli.compact);
+    }
+
+    #[test]
+    fn arg_parsing_compact() {
+        let cli = Cli::try_parse_from(["morph", "--compact", "-f", "json", "-t", "json"]).unwrap();
+        assert!(cli.compact);
+        assert!(!cli.pretty);
+    }
+
+    #[test]
+    fn arg_parsing_formats_flag() {
+        let cli = Cli::try_parse_from(["morph", "--formats"]).unwrap();
+        assert!(cli.formats);
+    }
+
+    // -- Format resolution --------------------------------------------------
+
+    #[test]
+    fn resolve_input_format_from_flag() {
+        let cli = Cli::try_parse_from(["morph", "-f", "json", "-t", "yaml"]).unwrap();
+        assert_eq!(cli.resolve_input_format().unwrap(), Format::Json);
+    }
+
+    #[test]
+    fn resolve_input_format_from_extension() {
+        let cli = Cli::try_parse_from(["morph", "-i", "data.yaml", "-t", "json"]).unwrap();
+        assert_eq!(cli.resolve_input_format().unwrap(), Format::Yaml);
+    }
+
+    #[test]
+    fn resolve_input_format_flag_overrides_extension() {
+        let cli =
+            Cli::try_parse_from(["morph", "-i", "data.yaml", "-f", "json", "-t", "toml"]).unwrap();
+        assert_eq!(cli.resolve_input_format().unwrap(), Format::Json);
+    }
+
+    #[test]
+    fn resolve_input_format_stdin_requires_flag() {
+        let cli = Cli::try_parse_from(["morph", "-t", "json"]).unwrap();
+        assert!(cli.resolve_input_format().is_err());
+    }
+
+    #[test]
+    fn resolve_output_format_from_flag() {
+        let cli = Cli::try_parse_from(["morph", "-f", "json", "-t", "yaml"]).unwrap();
+        assert_eq!(cli.resolve_output_format().unwrap(), Format::Yaml);
+    }
+
+    #[test]
+    fn resolve_output_format_from_extension() {
+        let cli = Cli::try_parse_from(["morph", "-f", "json", "-o", "out.toml"]).unwrap();
+        assert_eq!(cli.resolve_output_format().unwrap(), Format::Toml);
+    }
+
+    #[test]
+    fn resolve_unknown_extension_error() {
+        let cli = Cli::try_parse_from(["morph", "-i", "data.xyz", "-t", "json"]).unwrap();
+        let err = cli.resolve_input_format().unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("cannot detect format"), "msg: {msg}");
+        assert!(msg.contains("-f") || msg.contains("--from"), "msg: {msg}");
+    }
+
+    // -- Parse / serialize pipeline -----------------------------------------
+
+    #[test]
+    fn parse_and_serialize_json_to_yaml() {
+        let input = r#"{"name": "Alice", "age": 30}"#;
+        let val = parse_input(input, Format::Json).unwrap();
+        let output = serialize_output(&val, Format::Yaml, false).unwrap();
+        assert!(output.contains("name:"));
+        assert!(output.contains("Alice"));
+    }
+
+    #[test]
+    fn parse_and_serialize_yaml_to_json() {
+        let input = "name: Alice\nage: 30\n";
+        let val = parse_input(input, Format::Yaml).unwrap();
+        let output = serialize_output(&val, Format::Json, false).unwrap();
+        assert!(output.contains("\"name\""));
+        assert!(output.contains("\"Alice\""));
+    }
+
+    #[test]
+    fn format_display() {
+        assert_eq!(Format::Json.to_string(), "json");
+        assert_eq!(Format::Yaml.to_string(), "yaml");
+        assert_eq!(Format::Toml.to_string(), "toml");
+        assert_eq!(Format::Csv.to_string(), "csv");
+    }
+}

--- a/src/formats/csv.rs
+++ b/src/formats/csv.rs
@@ -1,1 +1,220 @@
-// TODO
+use crate::error;
+use crate::value::Value;
+use indexmap::IndexMap;
+use std::io::Read;
+
+/// Parse CSV data from a string into a Universal Value.
+///
+/// Returns an Array of Maps, where each map represents a row with header keys.
+pub fn from_str(input: &str) -> error::Result<Value> {
+    let mut rdr = csv::ReaderBuilder::new()
+        .has_headers(true)
+        .flexible(false)
+        .from_reader(input.as_bytes());
+
+    let headers: Vec<String> = rdr
+        .headers()
+        .map_err(|e| error::MorphError::format(e.to_string()))?
+        .iter()
+        .map(|h| h.to_string())
+        .collect();
+
+    let mut rows = Vec::new();
+    for result in rdr.records() {
+        let record = result?;
+        let mut map = IndexMap::new();
+        for (i, field) in record.iter().enumerate() {
+            let key = headers
+                .get(i)
+                .cloned()
+                .unwrap_or_else(|| format!("column_{i}"));
+            map.insert(key, parse_csv_field(field));
+        }
+        rows.push(Value::Map(map));
+    }
+
+    Ok(Value::Array(rows))
+}
+
+/// Serialize a Universal Value to a CSV string.
+///
+/// Expects the value to be an Array of Maps. All maps should have the same
+/// keys (the union of keys from the first row is used as the header).
+pub fn to_string(value: &Value) -> error::Result<String> {
+    let rows = match value {
+        Value::Array(arr) => arr,
+        _ => {
+            return Err(error::MorphError::format(
+                "CSV output requires an array of objects",
+            ))
+        }
+    };
+
+    if rows.is_empty() {
+        return Ok(String::new());
+    }
+
+    // Collect headers from the first row
+    let headers: Vec<String> = match &rows[0] {
+        Value::Map(map) => map.keys().cloned().collect(),
+        _ => return Err(error::MorphError::format("CSV rows must be objects (maps)")),
+    };
+
+    let mut wtr = csv::Writer::from_writer(Vec::new());
+    wtr.write_record(&headers)
+        .map_err(|e| error::MorphError::format(e.to_string()))?;
+
+    for row in rows {
+        match row {
+            Value::Map(map) => {
+                let fields: Vec<String> = headers
+                    .iter()
+                    .map(|h| map.get(h).map(csv_field_to_string).unwrap_or_default())
+                    .collect();
+                wtr.write_record(&fields)
+                    .map_err(|e| error::MorphError::format(e.to_string()))?;
+            }
+            _ => {
+                return Err(error::MorphError::format("CSV rows must be objects (maps)"));
+            }
+        }
+    }
+
+    let bytes = wtr
+        .into_inner()
+        .map_err(|e| error::MorphError::format(e.to_string()))?;
+    String::from_utf8(bytes).map_err(|e| error::MorphError::format(e.to_string()))
+}
+
+/// Read CSV from a reader.
+pub fn from_reader<R: Read>(reader: R) -> error::Result<Value> {
+    let mut rdr = csv::ReaderBuilder::new()
+        .has_headers(true)
+        .flexible(false)
+        .from_reader(reader);
+
+    let headers: Vec<String> = rdr
+        .headers()
+        .map_err(|e| error::MorphError::format(e.to_string()))?
+        .iter()
+        .map(|h| h.to_string())
+        .collect();
+
+    let mut rows = Vec::new();
+    for result in rdr.records() {
+        let record = result?;
+        let mut map = IndexMap::new();
+        for (i, field) in record.iter().enumerate() {
+            let key = headers
+                .get(i)
+                .cloned()
+                .unwrap_or_else(|| format!("column_{i}"));
+            map.insert(key, parse_csv_field(field));
+        }
+        rows.push(Value::Map(map));
+    }
+
+    Ok(Value::Array(rows))
+}
+
+/// Try to parse a CSV field into the most specific type.
+fn parse_csv_field(field: &str) -> Value {
+    if field.is_empty() {
+        return Value::String(String::new());
+    }
+
+    // Try bool
+    match field {
+        "true" => return Value::Bool(true),
+        "false" => return Value::Bool(false),
+        _ => {}
+    }
+
+    // Try int
+    if let Ok(i) = field.parse::<i64>() {
+        return Value::Int(i);
+    }
+
+    // Try float
+    if let Ok(f) = field.parse::<f64>() {
+        return Value::Float(f);
+    }
+
+    Value::String(field.to_string())
+}
+
+fn csv_field_to_string(value: &Value) -> String {
+    match value {
+        Value::Null => String::new(),
+        Value::Bool(b) => b.to_string(),
+        Value::Int(i) => i.to_string(),
+        Value::Float(f) => f.to_string(),
+        Value::String(s) => s.clone(),
+        Value::Bytes(b) => format!("{b:?}"),
+        Value::Array(_) | Value::Map(_) => {
+            // Flatten complex types to JSON for CSV cells
+            serde_json::to_string(&crate::formats::json::to_string(value).unwrap_or_default())
+                .unwrap_or_default()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_simple_csv() {
+        let input = "name,age\nAlice,30\nBob,25\n";
+        let val = from_str(input).unwrap();
+        let arr = match &val {
+            Value::Array(a) => a,
+            _ => panic!("expected array"),
+        };
+        assert_eq!(arr.len(), 2);
+        assert_eq!(
+            arr[0].get_path(".name"),
+            Some(&Value::String("Alice".into()))
+        );
+        assert_eq!(arr[0].get_path(".age"), Some(&Value::Int(30)));
+        assert_eq!(arr[1].get_path(".name"), Some(&Value::String("Bob".into())));
+    }
+
+    #[test]
+    fn roundtrip_csv() {
+        let input = "name,age\nAlice,30\nBob,25\n";
+        let val = from_str(input).unwrap();
+        let output = to_string(&val).unwrap();
+        let val2 = from_str(&output).unwrap();
+        assert_eq!(val, val2);
+    }
+
+    #[test]
+    fn csv_type_detection() {
+        let input = "s,i,f,b\nhello,42,3.15,true\n";
+        let val = from_str(input).unwrap();
+        let row = match &val {
+            Value::Array(a) => &a[0],
+            _ => panic!("expected array"),
+        };
+        assert_eq!(row.get_path(".s"), Some(&Value::String("hello".into())));
+        assert_eq!(row.get_path(".i"), Some(&Value::Int(42)));
+        assert_eq!(row.get_path(".f"), Some(&Value::Float(3.15)));
+        assert_eq!(row.get_path(".b"), Some(&Value::Bool(true)));
+    }
+
+    #[test]
+    fn csv_non_array_error() {
+        let val = Value::Map(IndexMap::new());
+        let result = to_string(&val);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn csv_empty_input() {
+        // A CSV with just headers and no data rows
+        let input = "name,age\n";
+        let val = from_str(input).unwrap();
+        assert_eq!(val, Value::Array(vec![]));
+    }
+}

--- a/src/formats/json.rs
+++ b/src/formats/json.rs
@@ -1,1 +1,164 @@
-// TODO
+use crate::error;
+use crate::value::Value;
+use indexmap::IndexMap;
+
+/// Parse a JSON string into a Universal Value.
+pub fn from_str(input: &str) -> error::Result<Value> {
+    let json_val: serde_json::Value = serde_json::from_str(input)?;
+    Ok(json_to_value(json_val))
+}
+
+/// Serialize a Universal Value to a pretty-printed JSON string.
+pub fn to_string_pretty(value: &Value) -> error::Result<String> {
+    let json_val = value_to_json(value);
+    let s = serde_json::to_string_pretty(&json_val)
+        .map_err(|e| error::MorphError::format(e.to_string()))?;
+    Ok(s)
+}
+
+/// Serialize a Universal Value to a compact JSON string.
+pub fn to_string(value: &Value) -> error::Result<String> {
+    let json_val = value_to_json(value);
+    let s =
+        serde_json::to_string(&json_val).map_err(|e| error::MorphError::format(e.to_string()))?;
+    Ok(s)
+}
+
+fn json_to_value(json: serde_json::Value) -> Value {
+    match json {
+        serde_json::Value::Null => Value::Null,
+        serde_json::Value::Bool(b) => Value::Bool(b),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Value::Int(i)
+            } else if let Some(f) = n.as_f64() {
+                Value::Float(f)
+            } else {
+                // Fallback – shouldn't happen for normal JSON
+                Value::String(n.to_string())
+            }
+        }
+        serde_json::Value::String(s) => Value::String(s),
+        serde_json::Value::Array(arr) => Value::Array(arr.into_iter().map(json_to_value).collect()),
+        serde_json::Value::Object(obj) => {
+            let mut map = IndexMap::new();
+            for (k, v) in obj {
+                map.insert(k, json_to_value(v));
+            }
+            Value::Map(map)
+        }
+    }
+}
+
+fn value_to_json(value: &Value) -> serde_json::Value {
+    match value {
+        Value::Null => serde_json::Value::Null,
+        Value::Bool(b) => serde_json::Value::Bool(*b),
+        Value::Int(i) => serde_json::Value::Number((*i).into()),
+        Value::Float(f) => serde_json::Number::from_f64(*f)
+            .map_or(serde_json::Value::Null, serde_json::Value::Number),
+        Value::String(s) => serde_json::Value::String(s.clone()),
+        Value::Bytes(b) => {
+            // Represent bytes as an array of numbers in JSON
+            serde_json::Value::Array(
+                b.iter()
+                    .map(|byte| serde_json::Value::from(*byte))
+                    .collect(),
+            )
+        }
+        Value::Array(arr) => serde_json::Value::Array(arr.iter().map(value_to_json).collect()),
+        Value::Map(map) => {
+            let mut obj = serde_json::Map::new();
+            for (k, v) in map {
+                obj.insert(k.clone(), value_to_json(v));
+            }
+            serde_json::Value::Object(obj)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_simple_object() {
+        let input = r#"{"name": "Alice", "age": 30}"#;
+        let val = from_str(input).unwrap();
+        assert_eq!(val.get_path(".name"), Some(&Value::String("Alice".into())));
+        assert_eq!(val.get_path(".age"), Some(&Value::Int(30)));
+    }
+
+    #[test]
+    fn parse_nested_object() {
+        let input = r#"{"user": {"name": "Bob", "scores": [1, 2, 3]}}"#;
+        let val = from_str(input).unwrap();
+        assert_eq!(
+            val.get_path(".user.name"),
+            Some(&Value::String("Bob".into()))
+        );
+        assert_eq!(val.get_path(".user.scores[0]"), Some(&Value::Int(1)));
+    }
+
+    #[test]
+    fn parse_all_types() {
+        let input = r#"{"s": "hello", "i": 42, "f": 3.15, "b": true, "n": null, "a": [1]}"#;
+        let val = from_str(input).unwrap();
+        assert_eq!(val.get_path(".s"), Some(&Value::String("hello".into())));
+        assert_eq!(val.get_path(".i"), Some(&Value::Int(42)));
+        assert_eq!(val.get_path(".f"), Some(&Value::Float(3.15)));
+        assert_eq!(val.get_path(".b"), Some(&Value::Bool(true)));
+        assert_eq!(val.get_path(".n"), Some(&Value::Null));
+    }
+
+    #[test]
+    fn roundtrip_json() {
+        let input = r#"{"key":"value","num":42,"arr":[1,2,3]}"#;
+        let val = from_str(input).unwrap();
+        let output = to_string(&val).unwrap();
+        let val2 = from_str(&output).unwrap();
+        assert_eq!(val, val2);
+    }
+
+    #[test]
+    fn pretty_output() {
+        let input = r#"{"a":1}"#;
+        let val = from_str(input).unwrap();
+        let pretty = to_string_pretty(&val).unwrap();
+        assert!(pretty.contains('\n'));
+        assert!(pretty.contains("  "));
+    }
+
+    #[test]
+    fn compact_output() {
+        let input = r#"{"a": 1, "b": 2}"#;
+        let val = from_str(input).unwrap();
+        let compact = to_string(&val).unwrap();
+        assert!(!compact.contains('\n'));
+    }
+
+    #[test]
+    fn parse_error_has_location() {
+        let bad = "{ invalid }";
+        let err = from_str(bad).unwrap_err();
+        match err {
+            crate::error::MorphError::Format { line, column, .. } => {
+                assert!(line.is_some());
+                assert!(column.is_some());
+            }
+            other => panic!("expected Format error, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn empty_object() {
+        let val = from_str("{}").unwrap();
+        assert_eq!(val, Value::Map(IndexMap::new()));
+    }
+
+    #[test]
+    fn empty_array() {
+        let val = from_str("[]").unwrap();
+        assert_eq!(val, Value::Array(vec![]));
+    }
+}

--- a/src/formats/toml.rs
+++ b/src/formats/toml.rs
@@ -1,1 +1,119 @@
-// TODO
+use crate::error;
+use crate::value::Value;
+use indexmap::IndexMap;
+
+/// Parse a TOML string into a Universal Value.
+pub fn from_str(input: &str) -> error::Result<Value> {
+    let toml_val: toml::Value = toml::from_str(input)?;
+    Ok(toml_to_value(toml_val))
+}
+
+/// Serialize a Universal Value to a TOML string.
+pub fn to_string(value: &Value) -> error::Result<String> {
+    let toml_val = value_to_toml(value)
+        .ok_or_else(|| error::MorphError::format("TOML requires a top-level table (map)"))?;
+    let s =
+        toml::to_string_pretty(&toml_val).map_err(|e| error::MorphError::format(e.to_string()))?;
+    Ok(s)
+}
+
+fn toml_to_value(t: toml::Value) -> Value {
+    match t {
+        toml::Value::String(s) => Value::String(s),
+        toml::Value::Integer(i) => Value::Int(i),
+        toml::Value::Float(f) => Value::Float(f),
+        toml::Value::Boolean(b) => Value::Bool(b),
+        toml::Value::Datetime(dt) => Value::String(dt.to_string()),
+        toml::Value::Array(arr) => Value::Array(arr.into_iter().map(toml_to_value).collect()),
+        toml::Value::Table(table) => {
+            let mut map = IndexMap::new();
+            for (k, v) in table {
+                map.insert(k, toml_to_value(v));
+            }
+            Value::Map(map)
+        }
+    }
+}
+
+fn value_to_toml(value: &Value) -> Option<toml::Value> {
+    match value {
+        Value::Null => Some(toml::Value::String("null".to_string())),
+        Value::Bool(b) => Some(toml::Value::Boolean(*b)),
+        Value::Int(i) => Some(toml::Value::Integer(*i)),
+        Value::Float(f) => Some(toml::Value::Float(*f)),
+        Value::String(s) => Some(toml::Value::String(s.clone())),
+        Value::Bytes(b) => {
+            // Represent as array of ints
+            Some(toml::Value::Array(
+                b.iter()
+                    .map(|byte| toml::Value::Integer(*byte as i64))
+                    .collect(),
+            ))
+        }
+        Value::Array(arr) => {
+            let toml_arr: Vec<toml::Value> = arr.iter().filter_map(value_to_toml).collect();
+            Some(toml::Value::Array(toml_arr))
+        }
+        Value::Map(map) => {
+            let mut table = toml::map::Map::new();
+            for (k, v) in map {
+                if let Some(tv) = value_to_toml(v) {
+                    table.insert(k.clone(), tv);
+                }
+            }
+            Some(toml::Value::Table(table))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_simple_toml() {
+        let input = "name = \"Alice\"\nage = 30\n";
+        let val = from_str(input).unwrap();
+        assert_eq!(val.get_path(".name"), Some(&Value::String("Alice".into())));
+        assert_eq!(val.get_path(".age"), Some(&Value::Int(30)));
+    }
+
+    #[test]
+    fn parse_nested_toml() {
+        let input = "[user]\nname = \"Bob\"\n";
+        let val = from_str(input).unwrap();
+        assert_eq!(
+            val.get_path(".user.name"),
+            Some(&Value::String("Bob".into()))
+        );
+    }
+
+    #[test]
+    fn roundtrip_toml() {
+        let input = "key = \"value\"\nnum = 42\n";
+        let val = from_str(input).unwrap();
+        let output = to_string(&val).unwrap();
+        let val2 = from_str(&output).unwrap();
+        assert_eq!(val, val2);
+    }
+
+    #[test]
+    fn toml_requires_top_level_table() {
+        // TOML must have a top-level table; an array at root should error on serialization
+        let val = Value::Array(vec![Value::Int(1)]);
+        // value_to_toml produces Some(Array(...)) but toml::to_string_pretty
+        // will reject it because TOML top-level must be a table.
+        let result = to_string(&val);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_types() {
+        let input = "s = \"hello\"\ni = 42\nf = 3.15\nb = true\n";
+        let val = from_str(input).unwrap();
+        assert_eq!(val.get_path(".s"), Some(&Value::String("hello".into())));
+        assert_eq!(val.get_path(".i"), Some(&Value::Int(42)));
+        assert_eq!(val.get_path(".f"), Some(&Value::Float(3.15)));
+        assert_eq!(val.get_path(".b"), Some(&Value::Bool(true)));
+    }
+}

--- a/src/formats/yaml.rs
+++ b/src/formats/yaml.rs
@@ -1,1 +1,125 @@
-// TODO
+use crate::error;
+use crate::value::Value;
+use indexmap::IndexMap;
+
+/// Parse a YAML string into a Universal Value.
+pub fn from_str(input: &str) -> error::Result<Value> {
+    let yaml_val: serde_yaml::Value = serde_yaml::from_str(input)?;
+    Ok(yaml_to_value(yaml_val))
+}
+
+/// Serialize a Universal Value to a YAML string.
+pub fn to_string(value: &Value) -> error::Result<String> {
+    let yaml_val = value_to_yaml(value);
+    let s =
+        serde_yaml::to_string(&yaml_val).map_err(|e| error::MorphError::format(e.to_string()))?;
+    Ok(s)
+}
+
+fn yaml_to_value(yaml: serde_yaml::Value) -> Value {
+    match yaml {
+        serde_yaml::Value::Null => Value::Null,
+        serde_yaml::Value::Bool(b) => Value::Bool(b),
+        serde_yaml::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                Value::Int(i)
+            } else if let Some(f) = n.as_f64() {
+                Value::Float(f)
+            } else {
+                Value::String(n.to_string())
+            }
+        }
+        serde_yaml::Value::String(s) => Value::String(s),
+        serde_yaml::Value::Sequence(seq) => {
+            Value::Array(seq.into_iter().map(yaml_to_value).collect())
+        }
+        serde_yaml::Value::Mapping(map) => {
+            let mut m = IndexMap::new();
+            for (k, v) in map {
+                let key = match k {
+                    serde_yaml::Value::String(s) => s,
+                    other => format!("{other:?}"),
+                };
+                m.insert(key, yaml_to_value(v));
+            }
+            Value::Map(m)
+        }
+        serde_yaml::Value::Tagged(tagged) => yaml_to_value(tagged.value),
+    }
+}
+
+fn value_to_yaml(value: &Value) -> serde_yaml::Value {
+    match value {
+        Value::Null => serde_yaml::Value::Null,
+        Value::Bool(b) => serde_yaml::Value::Bool(*b),
+        Value::Int(i) => serde_yaml::Value::Number(serde_yaml::Number::from(*i)),
+        Value::Float(f) => serde_yaml::Value::Number(serde_yaml::Number::from(*f)),
+        Value::String(s) => serde_yaml::Value::String(s.clone()),
+        Value::Bytes(b) => {
+            // Represent bytes as a sequence of numbers
+            serde_yaml::Value::Sequence(
+                b.iter()
+                    .map(|byte| serde_yaml::Value::Number(serde_yaml::Number::from(*byte as u64)))
+                    .collect(),
+            )
+        }
+        Value::Array(arr) => serde_yaml::Value::Sequence(arr.iter().map(value_to_yaml).collect()),
+        Value::Map(map) => {
+            let mut m = serde_yaml::Mapping::new();
+            for (k, v) in map {
+                m.insert(serde_yaml::Value::String(k.clone()), value_to_yaml(v));
+            }
+            serde_yaml::Value::Mapping(m)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_simple_yaml() {
+        let input = "name: Alice\nage: 30\n";
+        let val = from_str(input).unwrap();
+        assert_eq!(val.get_path(".name"), Some(&Value::String("Alice".into())));
+        assert_eq!(val.get_path(".age"), Some(&Value::Int(30)));
+    }
+
+    #[test]
+    fn parse_nested_yaml() {
+        let input = "user:\n  name: Bob\n  scores:\n    - 1\n    - 2\n";
+        let val = from_str(input).unwrap();
+        assert_eq!(
+            val.get_path(".user.name"),
+            Some(&Value::String("Bob".into()))
+        );
+        assert_eq!(val.get_path(".user.scores[0]"), Some(&Value::Int(1)));
+    }
+
+    #[test]
+    fn roundtrip_yaml() {
+        let input = "key: value\nnum: 42\n";
+        let val = from_str(input).unwrap();
+        let output = to_string(&val).unwrap();
+        let val2 = from_str(&output).unwrap();
+        assert_eq!(val, val2);
+    }
+
+    #[test]
+    fn parse_all_types() {
+        let input = "s: hello\ni: 42\nf: 3.15\nb: true\nn: null\n";
+        let val = from_str(input).unwrap();
+        assert_eq!(val.get_path(".s"), Some(&Value::String("hello".into())));
+        assert_eq!(val.get_path(".i"), Some(&Value::Int(42)));
+        assert_eq!(val.get_path(".f"), Some(&Value::Float(3.15)));
+        assert_eq!(val.get_path(".b"), Some(&Value::Bool(true)));
+        assert_eq!(val.get_path(".n"), Some(&Value::Null));
+    }
+
+    #[test]
+    fn empty_mapping() {
+        let val = from_str("{}").unwrap();
+        assert_eq!(val, Value::Map(IndexMap::new()));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,9 @@
+use std::process;
+
 fn main() {
-    println!("morph v{}", env!("CARGO_PKG_VERSION"));
+    let cli = morph::cli::Cli::parse_args();
+    if let Err(e) = morph::cli::run(&cli) {
+        eprintln!("Error: {e}");
+        process::exit(1);
+    }
 }


### PR DESCRIPTION
## Summary
Implements the CLI using clap and wires up the full read → parse → serialize → write pipeline for all four v0.1.0 formats.

## Changes
- **CLI (src/cli.rs)**: Full clap-based argument parsing with `-i`/`-o`, `-f`/`-t`, `--pretty`/`--compact`, `--indent`, `--formats` flags
- **Format auto-detection**: From file extensions (`.json`, `.yaml`/`.yml`, `.toml`, `.csv`)
- **JSON reader/writer** (src/formats/json.rs): Parse and serialize with pretty/compact modes
- **YAML reader/writer** (src/formats/yaml.rs): Full serde_yaml integration
- **TOML reader/writer** (src/formats/toml.rs): With top-level table validation
- **CSV reader/writer** (src/formats/csv.rs): With automatic type detection (bool, int, float, string)
- **Main pipeline** (src/main.rs): Wires everything together
- **stdin/stdout support**: Reads from stdin when no `-i`, writes to stdout when no `-o`
- **TTY detection**: Pretty-prints by default to terminals, compact for pipes

## Tests
116 tests passing covering:
- Argument parsing and format resolution
- Format detection from extensions and names
- Each format: parsing, round-tripping, type handling, error cases
- Cross-format conversion (JSON↔YAML pipeline)

Fixes #12