### PR TITLE
fix: resolve clippy warnings breaking CI on main

### DIFF
--- a/src/mapping/eval.rs
+++ b/src/mapping/eval.rs
@@ -222,11 +222,8 @@ fn eval_binary_op(left: &Value, op: BinOp, right: &Value) -> error::Result<Value
             eval_arithmetic(left, right, |a, b| a / b, |a, b| a / b)
         }
         BinOp::Mod => {
-            match right {
-                Value::Int(0) => {
-                    return Err(error::MorphError::mapping("modulo by zero"));
-                }
-                _ => {}
+            if let Value::Int(0) = right {
+                return Err(error::MorphError::mapping("modulo by zero"));
             }
             eval_arithmetic(left, right, |a, b| a % b, |a, b| a % b)
         }

--- a/src/mapping/functions.rs
+++ b/src/mapping/functions.rs
@@ -207,7 +207,7 @@ fn fn_join(args: &[Value]) -> error::Result<Value> {
         }
     };
     let sep = to_str(&args[1]);
-    let parts: Vec<String> = arr.iter().map(|v| to_str(v)).collect();
+    let parts: Vec<String> = arr.iter().map(to_str).collect();
     Ok(Value::String(parts.join(&sep)))
 }
 
@@ -634,8 +634,8 @@ mod tests {
     #[test]
     fn test_to_float() {
         assert_eq!(
-            call_function("to_float", &[Value::String("3.14".into())]).unwrap(),
-            Value::Float(3.14)
+            call_function("to_float", &[Value::String("2.72".into())]).unwrap(),
+            Value::Float(2.72)
         );
         assert_eq!(
             call_function("to_float", &[Value::Int(42)]).unwrap(),
@@ -694,8 +694,8 @@ mod tests {
             Value::Int(5)
         );
         assert_eq!(
-            call_function("abs", &[Value::Float(-3.14)]).unwrap(),
-            Value::Float(3.14)
+            call_function("abs", &[Value::Float(-2.72)]).unwrap(),
+            Value::Float(2.72)
         );
     }
 


### PR DESCRIPTION
## Problem
CI on main is failing after #45 merge due to 3 clippy warnings treated as errors:

1. `clippy::single_match` — single-arm match for modulo-by-zero check in `eval.rs`
2. `clippy::redundant_closure` — unnecessary closure in `join()` in `functions.rs`
3. `clippy::approx_constant` — test values `3.14` detected as approximate PI in `functions.rs`

## Fix
- Replaced `match` with `if let` for the modulo-by-zero check
- Replaced `|v| to_str(v)` with `to_str` directly
- Changed test values from `3.14` to `2.72` to avoid PI detection

All 575 tests passing, clippy clean.