### PR TITLE
feat: add format-specific CLI options

### DIFF
--- a/src/formats/yaml.rs
+++ b/src/formats/yaml.rs
@@ -24,6 +24,20 @@ pub fn from_str(input: &str) -> error::Result<Value> {
     }
 }
 
+/// Parse a YAML string forcing multi-document mode.
+///
+/// Always returns an array of documents, even if there is only one.
+pub fn from_str_multi(input: &str) -> error::Result<Value> {
+    let docs: Vec<Value> = serde_yaml::Deserializer::from_str(input)
+        .map(|de| {
+            let yaml_val = serde_yaml::Value::deserialize(de).map_err(error::MorphError::from)?;
+            Ok(yaml_to_value(yaml_val))
+        })
+        .collect::<error::Result<Vec<Value>>>()?;
+
+    Ok(Value::Array(docs))
+}
+
 /// Parse YAML from a reader into a Universal Value.
 pub fn from_reader<R: Read>(mut reader: R) -> error::Result<Value> {
     let mut buf = String::new();


### PR DESCRIPTION
Adds format-specific CLI flags for fine-grained control over CSV, XML, and YAML parsing/serialization.

## New CLI Options

| Flag | Description |
|------|-------------|
| `--csv-delimiter <char>` | Custom field delimiter (`\\t` for tab, single char) |
| `--csv-no-header` | Input CSV has no header row; returns array of arrays |
| `--csv-header <fields>` | Override headers with comma-separated field names |
| `--xml-root <name>` | Root element name for XML output (default: `root`) |
| `--xml-attr-prefix <prefix>` | Attribute prefix for XML (default: `@`) |
| `--yaml-multi` | Force multi-document mode (always returns array) |

## Implementation Details

- CLI struct extended with format-specific fields via clap
- `parse_input_with_cli` / `serialize_output_with_cli` pass CLI options to format handlers
- `from_str_with_explicit_headers` added to CSV module for header override
- `from_str_multi` added to YAML module for forced multi-doc mode
- Format options silently ignored when not relevant (no errors for `--xml-root` on JSON→JSON)

## Tests

8 integration tests covering:
- Tab-delimited CSV (`--csv-delimiter`)
- Headerless CSV (`--csv-no-header`)
- Header override (`--csv-header`)
- Custom XML root element (`--xml-root`)
- Custom XML attribute prefix (`--xml-attr-prefix`)
- YAML multi-document mode (`--yaml-multi`)
- Single-doc YAML with `--yaml-multi` (wraps in array)
- Options ignored when unused format

Fixes #28