### PR TITLE
feat: add shell completions and help commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ serde_yaml = "0.9"
 toml = "0.8"
 csv = "1"
 clap = { version = "4", features = ["derive"] }
+clap_complete = "4"
 quick-xml = "0.31"
 rmp-serde = "1"
 rmpv = "1"

--- a/tests/cross_format.rs
+++ b/tests/cross_format.rs
@@ -1112,4 +1112,92 @@ mod cli_integration {
             .assert()
             .success();
     }
+
+    // -- Shell completions and help commands ---------------------------------
+
+    #[test]
+    fn cli_completions_bash() {
+        Command::cargo_bin("morph")
+            .unwrap()
+            .args(["--completions", "bash"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("morph"));
+    }
+
+    #[test]
+    fn cli_completions_zsh() {
+        Command::cargo_bin("morph")
+            .unwrap()
+            .args(["--completions", "zsh"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("morph"));
+    }
+
+    #[test]
+    fn cli_completions_fish() {
+        Command::cargo_bin("morph")
+            .unwrap()
+            .args(["--completions", "fish"])
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("morph"));
+    }
+
+    #[test]
+    fn cli_completions_unknown_shell() {
+        Command::cargo_bin("morph")
+            .unwrap()
+            .args(["--completions", "tcsh"])
+            .assert()
+            .failure()
+            .stderr(predicate::str::contains("unknown shell"));
+    }
+
+    #[test]
+    fn cli_formats_list_with_capabilities() {
+        let output = Command::cargo_bin("morph")
+            .unwrap()
+            .args(["--formats"])
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("JSON"), "expected JSON: {stdout}");
+        assert!(stdout.contains("YAML"), "expected YAML: {stdout}");
+        assert!(stdout.contains("CSV"), "expected CSV: {stdout}");
+        assert!(stdout.contains("XML"), "expected XML: {stdout}");
+        assert!(
+            stdout.contains("MessagePack"),
+            "expected MessagePack: {stdout}"
+        );
+        assert!(
+            stdout.contains("read, write"),
+            "expected capabilities: {stdout}"
+        );
+    }
+
+    #[test]
+    fn cli_functions_list() {
+        let output = Command::cargo_bin("morph")
+            .unwrap()
+            .args(["--functions"])
+            .output()
+            .unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(stdout.contains("lower(value)"), "expected lower: {stdout}");
+        assert!(stdout.contains("upper(value)"), "expected upper: {stdout}");
+        assert!(stdout.contains("trim("), "expected trim: {stdout}");
+        assert!(stdout.contains("to_int("), "expected to_int: {stdout}");
+        assert!(stdout.contains("keys("), "expected keys: {stdout}");
+        assert!(stdout.contains("if("), "expected if: {stdout}");
+        assert!(
+            stdout.contains("String:"),
+            "expected String category: {stdout}"
+        );
+        assert!(
+            stdout.contains("Collection:"),
+            "expected Collection category: {stdout}"
+        );
+    }
 }


### PR DESCRIPTION
Adds shell completion generation and enhanced help commands for discoverability.

## New CLI Options

| Flag | Description |
|------|-------------|
| `--completions <shell>` | Generate shell completions (bash, zsh, fish, powershell, elvish) |
| `--formats` | Enhanced format listing with tabular layout |
| `--functions` | List all built-in mapping functions with signatures |

## Shell Completions

Uses `clap_complete` to generate completions for all major shells:

```bash
# Install bash completions
morph --completions bash > ~/.local/share/bash-completion/completions/morph

# Install zsh completions
morph --completions zsh > ~/.zsh/completions/_morph

# Install fish completions
morph --completions fish > ~/.config/fish/completions/morph.fish
```

## Enhanced `--formats` Output

Now shows a formatted table:
```
Supported formats:

  FORMAT          EXTENSIONS   CAPABILITIES
  ──────          ──────────   ────────────
  JSON            json         read, write
  JSONL           jsonl, ndjson read, write
  ...
```

## `--functions` Output

Lists all 30+ built-in functions organized by category:
- **String:** lower, upper, trim, replace, contains, split, join, etc.
- **Type conversion:** to_int, to_float, to_string, to_bool, type_of
- **Math:** abs, min, max, floor, ceil, round
- **Null/existence:** is_null, is_array, coalesce, default
- **Collection:** keys, values, unique, first, last, sum, group_by
- **Conditional:** if

## Tests

6 integration tests:
- Bash/Zsh/Fish completion generation
- Unknown shell error handling
- `--formats` table output with all formats
- `--functions` output with categories and signatures

Fixes #30