### PR TITLE
feat: set up release-plz for automated versioning and changelog

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,31 @@
+name: Release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-plz:
+    name: Release-plz
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Features
+
+- Universal data format converter with mapping language
+- Support for JSON, YAML, TOML, CSV, XML, MessagePack, JSON Lines formats
+- Mapping language with rename, select, drop, set, cast, where, each, when, flatten, nest, sort, default operations
+- 30+ built-in functions (string, math, collection, type operations)
+- Streaming mode for large files (JSONL, CSV, JSON array)
+- Shell completions for bash, zsh, fish, PowerShell, elvish
+- Error UX with "did you mean?" suggestions for formats and functions
+- Performance benchmark suite with Criterion
+- cargo-dist setup for automated release builds

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,51 @@
+# git-cliff configuration for changelog generation
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+"""
+body = """
+{% if version -%}
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+## [Unreleased]
+{% endif -%}
+
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}
+- {% if commit.breaking %}**BREAKING**: {% endif %}{{ commit.message | upper_first }} \
+  ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/alvinreal/morph/commit/{{ commit.id }}))\
+{% endfor %}
+{% endfor %}
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+protect_breaking_commits = true
+filter_commits = false
+tag_pattern = "v[0-9].*"
+sort_commits = "newest"
+
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^doc", group = "Documentation" },
+    { message = "^perf", group = "Performance" },
+    { message = "^refactor", group = "Refactor" },
+    { message = "^style", group = "Styling" },
+    { message = "^test", group = "Testing" },
+    { message = "^chore", group = "Miscellaneous" },
+    { message = "^ci", group = "CI/CD" },
+    { message = "^build", group = "Build" },
+]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,15 @@
+# release-plz configuration
+# https://release-plz.dev/docs/config
+
+[workspace]
+# Use git-cliff for changelog generation
+changelog_config = "cliff.toml"
+
+[[package]]
+name = "morph"
+# Publish to crates.io when the release PR is merged
+publish = true
+# Generate changelog
+changelog_update = true
+# Run semver checks to catch breaking changes
+semver_check = true


### PR DESCRIPTION
Sets up [release-plz](https://release-plz.dev/) to automate version bumps, changelog generation, and crates.io publishing.

## How It Works

```
commit with conventional commits → release-plz opens Release PR →
merge PR → release-plz creates git tag → cargo-dist builds & publishes
```

### On every push to main:
1. release-plz analyzes commits since the last release
2. Determines version bump from conventional commit types:
   - `feat:` → minor version bump
   - `fix:` → patch version bump
   - `feat!:` or `BREAKING CHANGE:` → major version bump
   - `chore:`, `docs:`, `ci:` → no version bump
3. Opens a Release PR with:
   - Updated version in `Cargo.toml`
   - Updated `CHANGELOG.md` (grouped by commit type)
   - Semver compatibility check via `cargo-semver-checks`

### On merge of Release PR:
1. Creates a git tag (e.g. `v0.2.0`)
2. Publishes to crates.io (when `CARGO_REGISTRY_TOKEN` secret is set)
3. Triggers cargo-dist release workflow (set up in #67)

## Files Added

- `.github/workflows/release-plz.yml` — GitHub Action running on push to main
- `release-plz.toml` — Configuration (publish, changelog, semver checks)
- `cliff.toml` — git-cliff changelog template with grouped sections (Features, Bug Fixes, Documentation, Performance, etc.)
- `CHANGELOG.md` — Initial changelog with unreleased features

## Notes

- Requires `CARGO_REGISTRY_TOKEN` secret for crates.io publishing (can be added later)
- Works alongside cargo-dist (#67) — release-plz handles versioning, cargo-dist handles building
- All existing tests pass (658 unit + 72 integration)

Fixes #68