### PR TITLE
feat: add cargo-binstall metadata for pre-built binary installs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,13 @@ harness = false
 [profile.dist]
 inherits = "release"
 lto = "thin"
+
+# cargo-binstall support — download pre-built binaries from GitHub Releases
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/morph-{ target }.tar.xz"
+bin-dir = "morph{ binary-ext }"
+pkg-fmt = "txz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-url = "{ repo }/releases/download/v{ version }/morph-{ target }.zip"
+pkg-fmt = "zip"


### PR DESCRIPTION
Adds `[package.metadata.binstall]` to `Cargo.toml` so users can install morph with pre-built binaries instead of compiling from source.

## Usage

```bash
# Install cargo-binstall if you don't have it
cargo install cargo-binstall

# Install morph (downloads pre-built binary in seconds)
cargo binstall morph
```

## How It Works

- `cargo binstall morph` checks GitHub Releases for a pre-built binary matching the user's platform
- Downloads and installs in seconds (vs minutes for `cargo install`)
- Falls back to `cargo install morph` (compile from source) if no binary is available
- Works automatically with cargo-dist releases (#67) which use compatible naming conventions

## Configuration

```toml
[package.metadata.binstall]
pkg-url = "{ repo }/releases/download/v{ version }/morph-{ target }.tar.xz"
bin-dir = "morph{ binary-ext }"
pkg-fmt = "txz"

[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
pkg-url = "{ repo }/releases/download/v{ version }/morph-{ target }.zip"
pkg-fmt = "zip"
```

## Supported Platforms

Matches the cargo-dist build targets:
- `x86_64-unknown-linux-gnu` / `x86_64-unknown-linux-musl` / `aarch64-unknown-linux-gnu`
- `x86_64-apple-darwin` / `aarch64-apple-darwin`
- `x86_64-pc-windows-msvc` (uses .zip instead of .tar.xz)

Fixes #69